### PR TITLE
Add file count check in parse mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,5 @@ require (
 	golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
 	google.golang.org/api v0.5.0
+	google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514 // indirect
 )

--- a/sredocs.go
+++ b/sredocs.go
@@ -17,14 +17,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/google/sredocs/charter"
-	"github.com/google/sredocs/exporter/bigquery"
-	"github.com/google/sredocs/postmortem"
-	"github.com/google/sredocs/source/drive"
 	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/sredocs/charter"
+	"github.com/google/sredocs/exporter/bigquery"
+	"github.com/google/sredocs/postmortem"
+	"github.com/google/sredocs/source/drive"
 )
 
 var (
@@ -75,6 +76,11 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		if len(files) == 0 {
+			log.Fatalf("No files found in %d", parsePath)
+		}
+
 		for _, f := range files {
 			content, err := ioutil.ReadFile(filepath.Join(*parsePath, f.Name()))
 			if err != nil {


### PR DESCRIPTION
## What

* Add file count check before running through parse().

## Why 

* This program gives no response if there was no file to parse.

```
$ mkdir sredocs
$ sredocs -mode=parse -parse_kind=auto -parse_path=sredocs  -parse_output_path=/tmp
=> (None)
```
